### PR TITLE
Testing cause of the buggy pull

### DIFF
--- a/files/mirrors/debian-mirror-sync-check.sh
+++ b/files/mirrors/debian-mirror-sync-check.sh
@@ -42,10 +42,11 @@ function should_pull() {
     # Log input of function to stderr
     local_mirror_time_epoch=$(date -d "$local_mirror_time" +%s)
     upstream_time_epoch=$(date -d "$upstream_time" +%s)
+    current_time_epoch=$(date -d "$current_time" +%s)
 
     # If it has been less than 2 hours since the upstream mirror started updating,
     # then the mirror is considered up-to-date
-    if [ $upstream_time_epoch -gt $(date -d "$current_time - 2 hours" +%s) ]; then
+    if [ $upstream_time_epoch -gt $(($current_time_epoch - 7200)) ]; then
         # Log the operation above to stderr
 	echo "upstream is greater than current minus two hours" >&2
         echo "false"
@@ -67,7 +68,7 @@ if [ "$1" == "--test" ]; then
     return
 fi
 
-if [ $(should_pull "$(get_local_time)" "$(get_upstream_time) $(date -u)") == "true" ]; then
+if [ $(should_pull "$(get_local_time)" "$(get_upstream_time)" "$(date -u)") == "true" ]; then
     echo "Local mirror is out of date, pulling from upstream mirror. Upstream date: $(get_upstream_time), Local date: $(get_local_time) - current date: $(date -u)"
     cd ${MIRROR_DIRECTORY}
     /home/mirrors/bin/ftpsync sync:all

--- a/files/mirrors/debian-mirror-sync-check.sh
+++ b/files/mirrors/debian-mirror-sync-check.sh
@@ -44,11 +44,16 @@ function should_pull() {
     upstream_time_epoch=$(date -d "$upstream_time" +%s)
     current_time_epoch=$(date -d "$current_time" +%s)
 
+    # If the local mirror is more than 4 hours old, then the mirror is considered out of date
+    if [ $(($upstream_time_epoch - $local_mirror_time_epoch)) -gt 14400 ]; then
+        echo "true"
+        return
+    fi
+
     # If it has been less than 2 hours since the upstream mirror started updating,
     # then the mirror is considered up-to-date
     if [ $upstream_time_epoch -gt $(($current_time_epoch - 7200)) ]; then
         # Log the operation above to stderr
-	echo "upstream is greater than current minus two hours" >&2
         echo "false"
         return
     fi
@@ -58,7 +63,6 @@ function should_pull() {
     if [ $local_mirror_time_epoch -lt $upstream_time_epoch ]; then
         echo "true"
     else
-	echo "local is less than upstream" >&2
         echo "false"
     fi
 }

--- a/files/mirrors/debian-mirror-sync-check.sh
+++ b/files/mirrors/debian-mirror-sync-check.sh
@@ -47,7 +47,7 @@ function should_pull() {
     # then the mirror is considered up-to-date
     if [ $upstream_time_epoch -gt $(date -d "$current_time - 2 hours" +%s) ]; then
         # Log the operation above to stderr
-        # echo "upstream_time_epoch minus current_time: $(($upstream_time_epoch - $(date -d "$current_time" +%s)))" >&2
+	echo "upstream is greater than current minus two hours" >&2
         echo "false"
         return
     fi
@@ -57,6 +57,7 @@ function should_pull() {
     if [ $local_mirror_time_epoch -lt $upstream_time_epoch ]; then
         echo "true"
     else
+	echo "local is less than upstream" >&2
         echo "false"
     fi
 }

--- a/files/mirrors/debian-mirror-sync.timer
+++ b/files/mirrors/debian-mirror-sync.timer
@@ -1,9 +1,8 @@
 [Unit]
-Description=Timer to sync Debian Mirror at random minutes each hour
+Description=Timer to sync Debian Mirror every 15 minutes
 
 [Timer]
-OnCalendar=hourly
-RandomizedDelaySec=3600
+OnCalendar=*:0/15
 Persistent=true
 
 [Install]

--- a/files/mirrors/test-debian-mirror-sync.sh
+++ b/files/mirrors/test-debian-mirror-sync.sh
@@ -30,8 +30,10 @@ test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "
 # Same as above. The current time is just over 2 hours ago.
 test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 20:02:35 UTC 2024" "true"
 
-# Testing the sample where we had a misbehavior
+# Testing the sample where we had a misbehavior because old repo was too old
 test_should_pull "Thu Nov 28 16:21:17 UTC 2024" "Mon Dec  2 19:42:01 UTC 2024" "Mon Dec  2 09:40:11 PM UTC 2024" "true"
+# Local time is older than the upstream time, but the upstream time is less than 2 hours ago.
+test_should_pull "Wed Nov 20 16:42:05 UTC 2024" "Wed Nov 20 19:52:35 UTC 2024" "Wed Nov 20 20:58:35 UTC 2024" "false"
 
 # This should not be possible, but what if current time is older than the local time
 test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "false"

--- a/files/mirrors/test-debian-mirror-sync.sh
+++ b/files/mirrors/test-debian-mirror-sync.sh
@@ -21,14 +21,17 @@ function test_should_pull() {
 }
 
 # Local time is newer than the upstream time, so no pull.
-test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "false"
+#test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "false"
 # Same as above. The current time is different (and it does not matter)
-test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 21 18:02:35 UTC 2024" "false"
+#test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 21 18:02:35 UTC 2024" "false"
 
 # Local time is older than the upstream time, but the upstream time is less than 2 hours ago.
-test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 19:58:35 UTC 2024" "false"
+#test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 19:58:35 UTC 2024" "false"
 # Same as above. The current time is just over 2 hours ago.
-test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 20:02:35 UTC 2024" "true"
+#test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 20:02:35 UTC 2024" "true"
+
+# Testing the sample where we had a misbehavior
+test_should_pull "Thu Nov 28 16:21:17 UTC 2024" "Mon Dec  2 19:42:01 UTC 2024" "Mon Dec  2 09:40:11 PM UTC 2024" "true"
 
 # This should not be possible, but what if current time is older than the local time
-test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "false"
+#test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "false"

--- a/files/mirrors/test-debian-mirror-sync.sh
+++ b/files/mirrors/test-debian-mirror-sync.sh
@@ -21,17 +21,17 @@ function test_should_pull() {
 }
 
 # Local time is newer than the upstream time, so no pull.
-#test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "false"
+test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "false"
 # Same as above. The current time is different (and it does not matter)
-#test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 21 18:02:35 UTC 2024" "false"
+test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 21 18:02:35 UTC 2024" "false"
 
 # Local time is older than the upstream time, but the upstream time is less than 2 hours ago.
-#test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 19:58:35 UTC 2024" "false"
+test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 19:58:35 UTC 2024" "false"
 # Same as above. The current time is just over 2 hours ago.
-#test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 20:02:35 UTC 2024" "true"
+test_should_pull "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 20:02:35 UTC 2024" "true"
 
 # Testing the sample where we had a misbehavior
 test_should_pull "Thu Nov 28 16:21:17 UTC 2024" "Mon Dec  2 19:42:01 UTC 2024" "Mon Dec  2 09:40:11 PM UTC 2024" "true"
 
 # This should not be possible, but what if current time is older than the local time
-#test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "false"
+test_should_pull "Wed Nov 20 18:02:35 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "Wed Nov 20 17:42:05 UTC 2024" "false"


### PR DESCRIPTION
Current test output:
```
❯ ./test-debian-mirror-sync.sh 
Testing debian mirror update script
upstream is greater than current minus two hours
Test failed - expected |true|, got |false|

```